### PR TITLE
Allow .item, .alert and .bad classes to be overridden via validator.defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ The whole approach here is to define each form field (input, select, whatever) a
 | data-validate-length-range | Defines the minimum and/or maximum number of chars in the field (after trim). value can be `4,8` for example, or just `4` to set minimum chars only                                                                                                                                                                             |
 | data-validate-linked       | Defines the field which the current field’s value (the attribute is set on) should be compared to                                                                                                                                                                                                                               |
 | data-validate-minmax       | For type `number` only. Defines the minimum and/or maximum value that can be in that field                                                                                                                                                                                                                                      |
+The `.item` class can be overridden:
 
-
-
+~~~js
+    validator.defaults.classes.item = '.your-class';
+~~~
 
 ### Optional fields
 There is also support for optional fields, which are not validated, unless they have a value. The support for this feature is done by adding a class “optional” to a form element. Note that this should not be done along side the “required” attribute.

--- a/validator.js
+++ b/validator.js
@@ -37,7 +37,15 @@ var validator = (function($){
 	}
 
 	// defaults
-	defaults = { alerts:true };
+	defaults = {
+		alerts: true,
+		classes: {
+			item: 'item',
+			alert: 'alert',
+			bad: 'bad',
+			good: 'good'
+		}
+	};
 
 	/* Tests for each type of field (including Select element)
 	*/
@@ -224,31 +232,31 @@ var validator = (function($){
 
 	/* marks invalid fields
 	*/
-    mark = function( field, text ){
+	mark = function( field, text ){
 		if( !text || !field || !field.length )
 			return false;
 
 		// check if not already marked as a 'bad' record and add the 'alert' object.
 		// if already is marked as 'bad', then make sure the text is set again because i might change depending on validation
-		var item = field.parents('.item'),
+		var item = field.parents('.' + defaults.classes.item),
 			warning;
 
-		if( item.hasClass('bad') ){
+		if( item.hasClass(defaults.classes.bad) ){
 			if( defaults.alerts )
-				item.find('.alert').html(text);
+				item.find('.'+defaults.classes.alert).html(text);
 		}
 
 
-        else if( defaults.alerts ){
-            warning = $('<div class="alert">').html( text );
-            item.append( warning );
-        }
+		else if( defaults.alerts ){
+			warning = $('<div class="'+ defaults.classes.alert +'">').html( text );
+			item.append( warning );
+		}
 
-        item.removeClass('bad');
+		item.removeClass(defaults.classes.bad);
 		// a delay so the "alert" could be transitioned via CSS
-        setTimeout(function(){
-            item.addClass('bad');
-        }, 0);
+		setTimeout(function(){
+			item.addClass(defaults.classes.bad);
+		}, 0);
 	};
 	/* un-marks invalid fields
 	*/
@@ -258,9 +266,9 @@ var validator = (function($){
 			return false;
 		}
 
-		field.parents('.item')
-			 .removeClass('bad')
-			 .find('.alert').remove();
+		field.parents('.' + defaults.classes.item)
+			 .removeClass(defaults.classes.bad)
+			 .find('.'+ defaults.classes.alert).remove();
 	};
 
 	function testByType(type, value){


### PR DESCRIPTION
`validator` hardcodes a bunch of classes that should be configurable to work with people's existing HTML.

This PR adds and documents that ability, while keeping the default behaviour identical.
