### PR TITLE
Bugfix for non-optional fields being tested for having a value

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -326,7 +326,9 @@ var validator = (function($){
         lengthLimit     = data['validateLength'] ? (data['validateLength']+'').split(',') : false;
         minmax          = data['validateMinmax'] ? (data['validateMinmax']+'').split(',') : ''; // for type 'number', defines the minimum and/or maximum for the value as a number.
 
-        data.valid = tests.hasValue(data.val);
+        // Prevents non-required fields from being tested for having a value present
+        data.valid = $(this).attr('required') ? tests.hasValue(data.val) : true;
+
         // check if field has any value
         if( data.valid ){
             /* Validate the field's value is different than the placeholder attribute (and attribute exists)


### PR DESCRIPTION
At present there's a bug where fields that are not 'required' are incorrectly tested for the presence of a value. The documentation states that optional fields are only tested when they have a value present, but this isn't the case. This will fix that.
