### PR TITLE
Adding element itself to closest method

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -360,15 +360,12 @@ FormValidator.prototype = {
             return false;
         })
 
-        var parent;
-
-        // traverse parents
+        // test element itself and traverse parents
         while (el) {
-            parent = el.parentElement;
-            if (parent && parent[matchesFn](selector)) {
-                return parent;
+            if (el && el[matchesFn](selector)) {
+                return el;
             }
-            el = parent;
+            el = el.parentElement;
         }
 
         return null;


### PR DESCRIPTION
This may be needed when there is not wrap parent for the element and you need to mark and unmark the element itself.