### PR TITLE
Adding a find item function to settings

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -51,6 +51,9 @@ FormValidator.prototype = {
             item  : 'field',
             alert : 'alert',
             bad   : 'bad'
+        },
+        findItem : function( field ){
+            return this.closest(field, '.' + this.settings.classes.item)
         }
     },
 
@@ -256,7 +259,7 @@ FormValidator.prototype = {
 
         // check if not already marked as 'bad' and add the 'alert' object.
         // if already is marked as 'bad', then make sure the text is set again because i might change depending on validation
-        var item = this.closest(field, '.' + this.settings.classes.item),
+        var item = this.settings.findItem(field),
             alert = item.querySelector('.'+this.settings.classes.alert),
             warning;
 
@@ -287,7 +290,7 @@ FormValidator.prototype = {
             return false;
         }
 
-        var fieldWrap = this.closest(field, '.' + this.settings.classes.item);
+        var fieldWrap = this.settings.findItem(field);
 
         if( fieldWrap ){
             var warning = fieldWrap.querySelector('.'+ this.settings.classes.alert);

--- a/validator.js
+++ b/validator.js
@@ -259,7 +259,7 @@ FormValidator.prototype = {
 
         // check if not already marked as 'bad' and add the 'alert' object.
         // if already is marked as 'bad', then make sure the text is set again because i might change depending on validation
-        var item = this.settings.findItem(field),
+        var item = this.settings.findItem.call(this, field),
             alert = item.querySelector('.'+this.settings.classes.alert),
             warning;
 
@@ -290,7 +290,7 @@ FormValidator.prototype = {
             return false;
         }
 
-        var fieldWrap = this.settings.findItem(field);
+        var fieldWrap = this.settings.findItem.call(this, field);
 
         if( fieldWrap ){
             var warning = fieldWrap.querySelector('.'+ this.settings.classes.alert);


### PR DESCRIPTION
this.settings.findItem will have the default behaviour, but can be customised for the user if the element to get `marked` or `unmarked` is a sibling or not a parent for that matter. This is handy when some predefined templates and plugins for customised form controls are used so that you don't need to modify the HTML or plugin to put the validator to work. :)