### PR TITLE
add custom regexp to settings

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -129,19 +129,10 @@ FormValidator.prototype = {
             if( data.pattern ){
                 var regex, jsRegex;
 
-                switch( data.pattern ){
-                    case 'alphanumeric' :
-                        regex = this.settings.regex.alphanumeric
-                        break;
-                    case 'numeric' :
-                        regex = this.settings.regex.numeric
-                        break;
-                    case 'phone' :
-                        regex = this.settings.regex.phone
-                        break;
-                    default :
-                        regex = data.pattern;
-                }
+                if( typeof this.settings.regex[data.pattern] === 'undefined' )
+                    regex = data.pattern
+                else
+                    regex = this.settings.regex[data.pattern]
                 try{
                     jsRegex = new RegExp(regex).test(data.value);
                     if( data.value && !jsRegex ){


### PR DESCRIPTION
making possible to add customised regexp to settings.
It's still possible to add a regexp to the **pattern** attribute.
To create a customised pattern it would be possible after creating the FormValidator instance e.g.:
```
var validator = new FormValidator();
validator.settings.regex.money = /^\d+(\.\d{1,2})?$/;
```