### PR TITLE
RFC 1034

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -61,7 +61,7 @@
                 alphanumeric : /^[a-zA-Z0-9]+$/i,
                 email        : {
                     illegalChars : /[\(\)\<\>\,\;\:\\\/\"\[\]]/,
-                    filter       : /^.+@.+\..{2,6}$/ // exmaple email "steve@s-i.photo"
+                    filter       : /^.+@.+\..{2,63}$/ // exmaple email "steve@s-i.photo"
                 }
             },
             classes : {


### PR DESCRIPTION
Newer top-level domains such as ".network" triggered errors. 24 characters are currently the highest right now, but for future-readiness used 63 as per RFC 1034.